### PR TITLE
fixed embarassing copy-paste-error

### DIFF
--- a/R/phreeqc_write_pqi.R
+++ b/R/phreeqc_write_pqi.R
@@ -207,11 +207,4 @@ phr_tidy_PHREEQC <- function(x){
   result <- do.call("phr_input", sections) #gotta love do.call
   return(result)
 
-  purrr::walk(output,
-              write,
-              file = path,
-              ncolumns = 1,
-              append = TRUE,
-              sep = "\n")
-
 }


### PR DESCRIPTION
Uhm sorry it's me again. Found an embarassing copy-paste-error from my previous trainwreck-experience with git that resultet in code snippet duplicates from `phr_write_pqi` ending up somewhere in the `phr_tidy_PHREEQC`-code. I do not think it created any actual harm there (neither formal nor informal tests suggest it does) but it is nonetheless driving me nuts.

I promise to remain silent from now on for at least the rest of August (unless I find another major idioty like this one).